### PR TITLE
Update README.md

### DIFF
--- a/docs/SCM-BestPractices/README.md
+++ b/docs/SCM-BestPractices/README.md
@@ -4,7 +4,7 @@ _by the [Open Source Security Foundation (OpenSSF)](https://openssf.org) [Best P
 
 ## Intro
 
-Collaborative source code management platforms (such as GitHub and GitLab) play a critical role in modern software development, providing a central repository for storing, managing, and versioning source code as well as collaborating with a community of developers. However, they also represent a potential security risk if not properly configured. In this guide, we will explore the best practices for securing these platforms, covering topics that include user authentication, access control, permissions, monitoring, and logging.
+Collaborative source code management platforms (such as GitHub and GitLab) play a critical role in modern software development, providing a central repository for storing, managing, and versioning source code as well as collaborating with a community of developers. However, they also represent a potential security risk if not properly configured. In this guide, we will explore the best practices for securing these platforms, covering topics that include user authentication, access control, permissions, monitoring, and logging. For additional guidance on selecting configurations that enable cross-organization collaboration, consider the InnerSource Commmon's [guidance section on InnerSource strategy for source code management platform configuration](https://innersourcecommons.gitbook.io/managing-innersource-projects/innersource-tooling). 
 
 ## Audience
 


### PR DESCRIPTION
Added link to InnerSource Common's guidance page on SCM platform configuration. It focuses on configuration that enables collaboration and is a nice addition to this security focus guidance. 

There is already a link in other direction from https://innersourcecommons.gitbook.io/managing-innersource-projects/innersource-tooling to the OSSF guidance at https://best.openssf.org/SCM-BestPractices/ .

This was discussed in https://github.com/ossf/wg-best-practices-os-developers/issues/557 and one of the working group video calls.
